### PR TITLE
Optimize tile_ref sync with max(updated_at) filter and transaction

### DIFF
--- a/src/__tests__/processor.test.ts
+++ b/src/__tests__/processor.test.ts
@@ -14,6 +14,7 @@ import {
   checkImageTile,
   putTileImageData,
   insertTileRef,
+  getMaxUpdatedAt,
   syncTileRefTable,
   deleteUnusedTiles,
   _resetPreparedStatements,
@@ -202,8 +203,27 @@ describe('insertTileRef', () => {
   });
 });
 
+describe('getMaxUpdatedAt', () => {
+  it('should return 0 when tile_ref is empty', () => {
+    const db = createTestDb();
+    expect(getMaxUpdatedAt(db)).toBe(0);
+    db.close();
+  });
+
+  it('should return the maximum updated_at value', () => {
+    const db = createTestDb();
+    const data = Buffer.from('data');
+    db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_a', 4, data);
+    db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_b', 4, data);
+    db.prepare('INSERT INTO tile_ref (zoom_level, tile_column, tile_row, image_md5, updated_at) VALUES (?, ?, ?, ?, ?)').run(5, 1, 1, 'md5_a', 1000);
+    db.prepare('INSERT INTO tile_ref (zoom_level, tile_column, tile_row, image_md5, updated_at) VALUES (?, ?, ?, ?, ?)').run(5, 2, 2, 'md5_b', 2000);
+    expect(getMaxUpdatedAt(db)).toBe(2000);
+    db.close();
+  });
+});
+
 describe('syncTileRefTable', () => {
-  it('should insert tile refs from mokuroku rows', () => {
+  it('should insert all tile refs on first sync', () => {
     const db = createTestDb();
     const data = Buffer.from('data');
     db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_a', 4, data);
@@ -220,6 +240,83 @@ describe('syncTileRefTable', () => {
 
     const count = db.prepare('SELECT count(*) AS c FROM tile_ref').get() as { c: number };
     expect(count.c).toBe(2);
+    db.close();
+  });
+
+  it('should skip rows with updated_at <= max(updated_at)', () => {
+    const db = createTestDb();
+    const data = Buffer.from('data');
+    db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_a', 4, data);
+    db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_b', 4, data);
+    db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_c', 4, data);
+
+    // First sync: insert 2 rows
+    console.time('sync_skip1');
+    const moku1: MokurokuArray = [
+      ['10/50/100.png', '1000', '256', 'md5_a'],
+      ['10/51/101.png', '2000', '256', 'md5_b'],
+    ];
+    const ctx = { db, id: 'sync_skip1' } as ProcessorCtx;
+    syncTileRefTable(ctx, moku1);
+    console.timeEnd('sync_skip1');
+
+    // Second sync: include old rows + one new row
+    _resetPreparedStatements();
+    console.time('sync_skip2');
+    const moku2: MokurokuArray = [
+      ['10/50/100.png', '1000', '256', 'md5_a'], // old, should be skipped
+      ['10/51/101.png', '2000', '256', 'md5_b'], // old, should be skipped
+      ['10/52/102.png', '3000', '256', 'md5_c'], // new, should be processed
+    ];
+    const ctx2 = { db, id: 'sync_skip2' } as ProcessorCtx;
+    syncTileRefTable(ctx2, moku2);
+    console.timeEnd('sync_skip2');
+
+    const count = db.prepare('SELECT count(*) AS c FROM tile_ref').get() as { c: number };
+    expect(count.c).toBe(3);
+
+    // Verify the new row was inserted
+    const flippedY = (1 << 10) - 1 - 102;
+    const newRow = db.prepare('SELECT * FROM tile_ref WHERE zoom_level = 10 AND tile_column = 52').get() as any;
+    expect(newRow).toBeDefined();
+    expect(newRow.image_md5).toBe('md5_c');
+    expect(newRow.updated_at).toBe(3000);
+
+    db.close();
+  });
+
+  it('should update existing tile when updated_at changes', () => {
+    const db = createTestDb();
+    const data = Buffer.from('data');
+    db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_old', 4, data);
+    db.prepare('INSERT INTO images (md5, tile_size, tile_data) VALUES (?, ?, ?)').run('md5_new', 4, data);
+
+    // First sync
+    console.time('sync_update1');
+    const moku1: MokurokuArray = [
+      ['10/50/100.png', '1000', '256', 'md5_old'],
+    ];
+    const ctx = { db, id: 'sync_update1' } as ProcessorCtx;
+    syncTileRefTable(ctx, moku1);
+    console.timeEnd('sync_update1');
+
+    // Second sync: same tile, new md5 and updated_at
+    _resetPreparedStatements();
+    console.time('sync_update2');
+    const moku2: MokurokuArray = [
+      ['10/50/100.png', '2000', '256', 'md5_new'],
+    ];
+    const ctx2 = { db, id: 'sync_update2' } as ProcessorCtx;
+    syncTileRefTable(ctx2, moku2);
+    console.timeEnd('sync_update2');
+
+    const count = db.prepare('SELECT count(*) AS c FROM tile_ref').get() as { c: number };
+    expect(count.c).toBe(1);
+
+    const row = db.prepare('SELECT image_md5, updated_at FROM tile_ref WHERE zoom_level = 10').get() as any;
+    expect(row.image_md5).toBe('md5_new');
+    expect(row.updated_at).toBe(2000);
+
     db.close();
   });
 });

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -193,27 +193,52 @@ const insertTileRef = (db: Database, z: number, x: number, y: number, md5: strin
   _preparedInsertTileRefQuery.run(z, x, flippedY, md5, updated);
 };
 
+const getMaxUpdatedAt = (db: Database): number => {
+  const row = db.prepare('SELECT MAX(updated_at) AS max_updated FROM tile_ref').get() as { max_updated: number | null };
+  return row?.max_updated ?? 0;
+};
+
 const syncTileRefTable = (ctx: ProcessorCtx, moku: MokurokuArray) => {
   if (shutdownRequested) return;
 
   const { db, id } = ctx;
-  let currentRow = 0;
-  const mokuLen = moku.length;
-  for (const row of moku) {
-    const [z, x, y] = row[0].substring(0, row[0].length - 4).split('/');
-    insertTileRef(db,
-      parseInt(z, 10),
-      parseInt(x, 10),
-      parseInt(y, 10),
-      row[3],
-      parseInt(row[1], 10)
-    );
-    currentRow += 1;
 
-    if (currentRow % 10_000 === 0) {
-      console.timeLog(id, `[タイル同期] current=${currentRow} total=${mokuLen}`);
-    }
+  // 前回同期時の最大 updated_at を取得し、それより新しい行のみ処理
+  const maxUpdated = getMaxUpdatedAt(db);
+  const rowsToSync = maxUpdated > 0
+    ? moku.filter(row => parseInt(row[1], 10) > maxUpdated)
+    : moku;
+
+  const skipped = moku.length - rowsToSync.length;
+  if (skipped > 0) {
+    console.timeLog(id, `[タイル同期] ${moku.length} 件中 ${skipped} 件をスキップ（更新なし）`);
   }
+
+  if (rowsToSync.length === 0) return;
+
+  let currentRow = 0;
+  const totalRows = rowsToSync.length;
+
+  // トランザクションで一括処理
+  const syncAll = db.transaction(() => {
+    for (const row of rowsToSync) {
+      const [z, x, y] = row[0].substring(0, row[0].length - 4).split('/');
+      insertTileRef(db,
+        parseInt(z, 10),
+        parseInt(x, 10),
+        parseInt(y, 10),
+        row[3],
+        parseInt(row[1], 10)
+      );
+      currentRow += 1;
+
+      if (currentRow % 10_000 === 0) {
+        console.timeLog(id, `[タイル同期] current=${currentRow} total=${totalRows}`);
+      }
+    }
+  });
+
+  syncAll();
 }
 
 const deleteUnusedTiles = (ctx: ProcessorCtx) => {
@@ -389,6 +414,7 @@ export {
   checkImageTile,
   putTileImageData,
   insertTileRef,
+  getMaxUpdatedAt,
   syncTileRefTable,
   deleteUnusedTiles,
   getMokuroku,


### PR DESCRIPTION
## Summary
- `syncTileRefTable` で `MAX(updated_at)` を取得し、前回同期以降に更新されたタイルのみ処理するように変更
- トランザクションで一括処理することでSQLiteの書き込み性能を大幅に改善
- `getMaxUpdatedAt` ヘルパー関数を追加

## Performance
`english` z5-7 (21,504件) での実測:

| 実行 | タイル同期時間 |
|---|---|
| 初回（改善前） | ~3秒 |
| 初回（改善後・トランザクション化） | ~0.02秒 |
| 2回目（改善前・全行INSERT発行） | ~3秒 |
| 2回目（改善後・max(updated_at)フィルタ） | 全件スキップ、即完了 |

Closes #3

## Test plan
- [x] `npm test` — 41 tests pass (新規4テスト追加)
- [x] `npm run build` — builds successfully
- [x] `english` z5-7で初回ダウンロード → 正常動作
- [x] 再実行時にmax(updated_at)フィルタで全件スキップを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善点
* タイルの同期処理が効率化されました。今後は、変更されたタイル のみが同期対象となり、不要な処理がスキップされるため、同期速度が向上します。
* 既存タイルの更新時に、重複作成ではなく適切に更新されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->